### PR TITLE
Conditionally bypass Docker 'platform' option, update dependencies

### DIFF
--- a/lib/build.ts
+++ b/lib/build.ts
@@ -121,6 +121,8 @@ export async function runBuildTask(
 	// which is why we check for 1.38 here
 	const usePlatformOption: boolean =
 		!!task.dockerPlatform &&
+		// workaround for `balena build` with Docker v20.10
+		task.dockerPlatform !== 'none' &&
 		semver.satisfies(
 			semver.coerce((await docker.version()).ApiVersion) || '0.0.0',
 			'>=1.38.0',

--- a/lib/external.ts
+++ b/lib/external.ts
@@ -38,8 +38,7 @@ export function pullExternal(
 	task: BuildTask,
 	docker: Dockerode,
 ): Bluebird<LocalImage> {
-	const dockerProgress = new DockerProgress();
-	dockerProgress.docker.modem = docker.modem;
+	const dockerProgress = new DockerProgress({ docker });
 
 	const progressHook = _.isFunction(task.progressHook)
 		? task.progressHook

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -56,6 +56,7 @@ export * from './errors';
 export * from './local-image';
 export * from './registry-secrets';
 export { resolveDockerPlatform } from './resolve';
+export { getRegistryAndName } from './utils';
 export { BalenaYml, ParsedBalenaYml };
 export { PathUtils };
 export { ResolveListeners };
@@ -318,6 +319,8 @@ export async function initializeBuildMetadata(
 	const hasSecrets = !_.isEmpty(secretMap);
 
 	if (hasSecrets) {
+		// TODO: investigate the purpose of this `populateSecrets`
+		// call. Could it be simply deleted?
 		await populateSecrets(docker, secretMap, architecture, tmpDir);
 	}
 

--- a/lib/registry-secrets.ts
+++ b/lib/registry-secrets.ts
@@ -23,8 +23,6 @@
 
 import * as ajv from 'ajv';
 
-import DockerToolbelt = require('docker-toolbelt');
-
 import { RegistrySecretValidationError } from './errors';
 export { RegistrySecretValidationError } from './errors';
 
@@ -159,9 +157,8 @@ export async function getAuthConfigObj(
 	imageName: string,
 	registryconfig: RegistrySecrets,
 ): Promise<RegistrySecrets | {}> {
-	const { registry } = await new DockerToolbelt({}).getRegistryAndName(
-		imageName,
-	);
+	const { getRegistryAndName } = await import('./utils');
+	const { registry } = getRegistryAndName(imageName);
 	// If the imageName was prefixed by a domain name or IP address,
 	// use it to query the registryconfig and return.
 	if (registry) {

--- a/lib/resolve.ts
+++ b/lib/resolve.ts
@@ -45,13 +45,15 @@ export function resolveTask(
 	additionalVars: Dictionary<string> = {},
 	dockerfilePreprocessHook?: (content: string) => string,
 ): BuildTask {
-	// do this first, to also signal proper platform to pulls
-	// and fall back to old behavior, if no match was found
-	const platform = resolveDockerPlatform(architecture);
-	if (platform) {
-		task.dockerPlatform = platform;
+	// Workaround for Docker v20.10: skip platform resolution if the
+	// balena CLI sets `dockerPlatform` to 'none'.
+	if (task.dockerPlatform !== 'none') {
+		// set the platform / architecture for pulling multiarch images
+		const platform = resolveDockerPlatform(architecture);
+		if (platform) {
+			task.dockerPlatform = platform;
+		}
 	}
-
 	if (task.external) {
 		// No resolution needs to be performed for external images
 		return task;

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
   "dependencies": {
     "ajv": "^6.12.3",
     "bluebird": "^3.7.2",
-    "docker-progress": "^4.0.1",
-    "docker-toolbelt": "^3.3.8",
+    "docker-progress": "^5.0.0",
     "dockerfile-template": "^0.2.0",
     "dockerode": "^2.5.8",
     "fp-ts": "^2.8.1",


### PR DESCRIPTION
Two commits (in the same PR because they were tested together) -
* One commit allows the Docker build image API `platform` option to be bypassed by setting `task.dockerPlatform` to `'none'`, which `balena-cli` can do to avoid `balena build` failing when used with Docker v20.10. Related to: https://www.flowdock.com/app/rulemotion/i-cli/threads/RuSu1KiWOn62xaGy7O2sn8m8BUc
This was necessary because, otherwise, the CLI could not use the latest version of `balena-multibuild`, including the other commit in this PR.

* Bump `docker-progress` and remove the dependency on `docker-toolbelt`, as explained in PR comments and as part of the investigation of issue balena-io/balena-cli/issues/2165 (Node.js v14 support by the balena CLI).