### PR TITLE
Fix accidental 'it.only' in test cases and update @balena/lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/resin-io-modules/resin-multibuild#readme",
   "devDependencies": {
-    "@balena/lint": "^5.4.1",
+    "@balena/lint": "^6.1.1",
     "@types/bluebird": "^3.5.32",
     "@types/chai-as-promised": "^7.1.3",
     "@types/dockerode": "^2.5.34",

--- a/test/build-utils.ts
+++ b/test/build-utils.ts
@@ -77,7 +77,7 @@ function getDockerOpts(extraOpts?: any): Dockerode.DockerOptions {
 
 export function fileToTarPack(filename: string): tar.Pack {
 	// A little hacky, but it's fine for the tests
-	return (fs.createReadStream(filename) as any) as tar.Pack;
+	return fs.createReadStream(filename) as any as tar.Pack;
 }
 
 export async function checkExists(

--- a/test/build.spec.ts
+++ b/test/build.spec.ts
@@ -257,7 +257,7 @@ describe('Resolved project building', () => {
 			});
 	});
 
-	it.only('should correctly build a resolved project when task.dockerPlatform is "none"', async function () {
+	it('should correctly build a resolved project when task.dockerPlatform is "none"', async function () {
 		const task: BuildTask = {
 			external: false,
 			resolved: false,

--- a/test/resolve.spec.ts
+++ b/test/resolve.spec.ts
@@ -21,9 +21,9 @@ describe('Project resolution', () => {
 		const task: BuildTask = {
 			external: false,
 			resolved: false,
-			buildStream: (fs.createReadStream(
+			buildStream: fs.createReadStream(
 				'test/test-files/templateProject.tar',
-			) as any) as Pack,
+			) as any as Pack,
 			serviceName: 'test',
 			buildMetadata,
 		};
@@ -53,9 +53,9 @@ describe('Project resolution', () => {
 			external: false,
 			resolved: false,
 			serviceName: 'test',
-			buildStream: (fs.createReadStream(
+			buildStream: fs.createReadStream(
 				'test/test-files/failedProject.tar',
-			) as any) as Pack,
+			) as any as Pack,
 			buildMetadata,
 		};
 
@@ -77,9 +77,9 @@ describe('Project resolution', () => {
 		const task: BuildTask = {
 			external: false,
 			resolved: false,
-			buildStream: (fs.createReadStream(
+			buildStream: fs.createReadStream(
 				'test/test-files/additional-template-vars.tar',
-			) as any) as Pack,
+			) as any as Pack,
 			serviceName: 'test',
 			buildMetadata,
 		};
@@ -111,9 +111,9 @@ describe('Project resolution', () => {
 		const task: BuildTask = {
 			external: false,
 			resolved: false,
-			buildStream: (fs.createReadStream(
+			buildStream: fs.createReadStream(
 				'test/test-files/templateProject.tar',
-			) as any) as Pack,
+			) as any as Pack,
 			serviceName: 'test',
 			buildMetadata,
 		};


### PR DESCRIPTION
Fixes an `it.only` that I accidentally left behind in PR #88. Thanks to @toochevere for spotting it. 👍 

While at it, I've also updated `@balena/lint` to v6.

See: https://www.flowdock.com/app/rulemotion/resin-tech/threads/7wsZ5WSl1o5Epcpkz8wNDVO2_FI