### PR TITLE
Add build task option to use default docker platform behavior

### DIFF
--- a/lib/build-task.ts
+++ b/lib/build-task.ts
@@ -124,9 +124,15 @@ export interface BuildTask {
 	 * The platform string used used by docker resolve the correct
 	 * image in manifest lists.
 	 * Populated in the resolution step by translating from the
-	 * architecture property.
+	 * architecture property unless `useDefaultPlatformOnly` is `true`.
 	 */
 	dockerPlatform?: string;
+
+	/**
+	 * If true, then do not attempt to query base image manifests for a matching platform.
+	 * The default platform platform (builder arch) will be used.
+	 */
+	useDefaultPlatformForMultiarchBaseImages?: boolean;
 
 	/**
 	 * The container contract for this service

--- a/lib/build.ts
+++ b/lib/build.ts
@@ -133,7 +133,8 @@ export async function runBuildTask(
 			semver.coerce((await docker.version()).ApiVersion) || '0.0.0',
 			'>=1.38.0',
 		) &&
-		(await checkAllowDockerPlatformHandling(task, docker));
+		(task.useDefaultPlatformForMultiarchBaseImages ||
+			(await checkAllowDockerPlatformHandling(task, docker)));
 
 	task.dockerOpts = _.merge(
 		usePlatformOption ? { platform: task.dockerPlatform } : {},

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lodash": "^4.17.19",
     "resin-bundle-resolve": "^4.3.0",
     "@balena/compose-parse": "^3.0.0",
-    "resin-docker-build": "^1.1.5",
+    "resin-docker-build": "^1.1.6",
     "semver": "^7.3.5",
     "tar-stream": "^2.1.3",
     "tar-utils": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/bluebird": "^3.5.32",
     "@types/chai-as-promised": "^7.1.3",
     "@types/docker-modem": "^3.0.1",
-    "@types/dockerode": "^2.5.34",
+    "@types/dockerode": "^3.3.9",
     "@types/js-yaml": "^4.0.1",
     "@types/lodash": "^4.14.168",
     "@types/mocha": "^8.2.2",
@@ -51,7 +51,7 @@
   "dependencies": {
     "ajv": "^6.12.3",
     "bluebird": "^3.7.2",
-    "docker-progress": "^5.0.0",
+    "docker-progress": "^5.1.3",
     "dockerfile-ast": "^0.2.1",
     "dockerfile-template": "^0.2.0",
     "dockerode": "^3.3.1",


### PR DESCRIPTION
Change-type: minor

This change is to unblock the latest version of multibuild from being used in the builder.  Because builder nodes are running the hacked kernel, we do not want multibuild to calculate the arch and pass it to Docker (we want the default behavior that the hacked kernel exposes).  

A small change will be coming to the builder so that build tasks will set the new build task flag for default behavior.